### PR TITLE
Fixed Fab showing up exploded on first composition

### DIFF
--- a/app/src/main/java/com/wajahatkarim3/droidcon/emea2020/TransitionsDemo.kt
+++ b/app/src/main/java/com/wajahatkarim3/droidcon/emea2020/TransitionsDemo.kt
@@ -23,7 +23,7 @@ val fabColorKey = ColorPropKey()
 val fabIconAlphaKey = FloatPropKey()
 
 enum class FabSizeState {
-    NORMAL, EXPLODED
+    INITIAL, NORMAL, EXPLODED
 }
 
 @Composable
@@ -34,6 +34,15 @@ fun ExplodingFabButton() {
 
 
     val fabTransitionDef = transitionDefinition<FabSizeState> {
+        // What happens initially, this is used to prevent
+        // transitioning to the next state until fabSizeState
+        // becomes NORMAL or EXPLODED on click
+        state(FabSizeState.INITIAL) {
+            this[fabSizeKey] = 80f
+            this[fabColorKey] = secondaryColor
+            this[fabIconAlphaKey] = 1f
+        }
+        
         // What happens when Normal
         state(FabSizeState.NORMAL) {
             this[fabSizeKey] = 80f

--- a/app/src/main/java/com/wajahatkarim3/droidcon/emea2020/TransitionsDemo.kt
+++ b/app/src/main/java/com/wajahatkarim3/droidcon/emea2020/TransitionsDemo.kt
@@ -28,19 +28,18 @@ enum class FabSizeState {
 
 @Composable
 fun ExplodingFabButton() {
-    val fabSizeState = remember { mutableStateOf(FabSizeState.NORMAL) }
+    val fabSizeState = remember { mutableStateOf(FabSizeState.INITIAL) }
     val secondaryColor = MaterialTheme.colors.secondary
     val primaryColor = MaterialTheme.colors.primary
 
 
     val fabTransitionDef = transitionDefinition<FabSizeState> {
-        // What happens initially, this is used to prevent
-        // transitioning to the next state until fabSizeState
-        // becomes NORMAL or EXPLODED on click
+        // What happens Initially, on first render
+        // a transition automatically runs from INITIAL to NORMAL
         state(FabSizeState.INITIAL) {
-            this[fabSizeKey] = 80f
+            this[fabSizeKey] = 20f
             this[fabColorKey] = secondaryColor
-            this[fabIconAlphaKey] = 1f
+            this[fabIconAlphaKey] = 0f
         }
         
         // What happens when Normal


### PR DESCRIPTION
It seems like due to the following line, to animation runs from `NORMAL` to `EXPLODED` as soon as the ExplodingFabButton is rendered for the first time. Adding an `INITIAL` state means that this first animation goes from `INITIAL` to `NORMAL` and then further taps just switch between `NORMAL` and `EXPLODED`.

This `INITIAL` state here is used to animate in the Fab into the `NORMAL` state.

https://github.com/androidx/androidx/blob/androidx-master-dev/compose/animation/animation/src/commonMain/kotlin/androidx/compose/animation/Transition.kt#L95
